### PR TITLE
fix: Agregar cast explícito a BufferSource para writeBuffer

### DIFF
--- a/src/engine/WebGPUEngine.ts
+++ b/src/engine/WebGPUEngine.ts
@@ -895,7 +895,7 @@ export class WebGPUEngine {
     });
 
     // Escribir datos de geometría
-    this.device.queue.writeBuffer(buffer, 0, shapeGeometry.vertices);
+    this.device.queue.writeBuffer(buffer, 0, shapeGeometry.vertices as BufferSource);
 
     // Actualizar contador de vértices
     this.currentShapeVertexCount = shapeGeometry.vertexCount;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety in GPU buffer operations for geometry data uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->