### PR TITLE
fix: Corregir animaciones que no se reproducían correctamente

### DIFF
--- a/src/engine/animation-configs.ts
+++ b/src/engine/animation-configs.ts
@@ -82,11 +82,11 @@ export const ANIMATION_DEFAULTS: Record<AnimationType, AnimationDefaults> = {
   dynamicMaze: { frequency: 0.3, amplitude: 4.0, elasticity: 0.7, maxLength: 90 },
 
   // NUEVAS ANIMACIONES
-  interferenceWaves: { frequency: 1.5, amplitude: 30, elasticity: 2.0, maxLength: 120 },
+  interferenceWaves: { frequency: 3.0, amplitude: 30, elasticity: 2.0, maxLength: 120 },
   particleFlow: { frequency: 0.8, amplitude: 1.2, elasticity: 0.6, maxLength: 110 },
-  animatedFractals: { frequency: 0.5, amplitude: 1.8, elasticity: 4.0, maxLength: 100 },
+  animatedFractals: { frequency: 0.5, amplitude: 1.8, elasticity: 10.0, maxLength: 100 },
   crystallization: { frequency: 0.8, amplitude: 6.0, elasticity: 0.5, maxLength: 130 },
-  shockWaves: { frequency: 1.2, amplitude: 4.0, elasticity: 0.7, maxLength: 140 },
+  shockWaves: { frequency: 1.2, amplitude: 4.0, elasticity: 0.3, maxLength: 140 },
 
   // 3D ANIMATIONS
   smoothWaves3D: { frequency: 0.1, amplitude: 1.0, elasticity: 0, maxLength: 80 },

--- a/src/engine/shaders/compute/animations.wgsl.ts
+++ b/src/engine/shaders/compute/animations.wgsl.ts
@@ -1905,7 +1905,7 @@ fn computeMain(@builtin(global_invocation_id) global_id: vec3u) {
   // Normalizar y aplicar amplitud
   totalWave = totalWave / numSources;
   let targetAngle = totalWave * amplitude;
-  vector.angle = normalize_angle(targetAngle);
+  vector.angle = lerp_angle(vector.angle, targetAngle, 0.15);
 
   // Modulación de longitud basada en interferencia
   let lengthMod = 1.0 + abs(totalWave) * 0.5;
@@ -2033,7 +2033,7 @@ fn computeMain(@builtin(global_invocation_id) global_id: vec3u) {
   let originalAngle = atan2(normY, normX);
   let targetAngle = mix(escapeAngle, originalAngle, mixFactor);
 
-  vector.angle = normalize_angle(targetAngle);
+  vector.angle = lerp_angle(vector.angle, targetAngle, 0.1);
 
   // Longitud basada en velocidad de escape
   let lengthMod = 0.3 + (1.0 - mixFactor) * 1.2;
@@ -2101,7 +2101,7 @@ fn computeMain(@builtin(global_invocation_id) global_id: vec3u) {
   let frontInfluence = exp(-distToFront * 0.01);
   let targetAngle = mix(angle, growthAngle, frontInfluence);
 
-  vector.angle = normalize_angle(targetAngle);
+  vector.angle = lerp_angle(vector.angle, targetAngle, 0.12);
 
   // Longitud mayor en el frente de crecimiento
   let lengthMod = 0.5 + frontInfluence * 1.0 + abs(branchNoise) * 0.5;
@@ -2174,7 +2174,7 @@ fn computeMain(@builtin(global_invocation_id) global_id: vec3u) {
   }
 
   let targetAngle = atan2(totalForceY, totalForceX);
-  vector.angle = normalize_angle(targetAngle);
+  vector.angle = lerp_angle(vector.angle, targetAngle, 0.15);
 
   // Longitud basada en intensidad de la onda
   let lengthMod = 0.3 + maxIntensity * 2.0;


### PR DESCRIPTION
Problemas corregidos:

1. interferenceWaves: Aumentar frequency de 1.5 a 3.0
   - Con floor(1.5)=1 solo había 1 fuente, insuficiente para ver patrones de interferencia
   - Ahora con 3 fuentes se crean patrones visibles

2. animatedFractals: Aumentar elasticity (iteraciones) de 4.0 a 10.0
   - 4 iteraciones eran muy pocas para ver detalles fractales
   - 10 iteraciones generan patrones más complejos y visibles

3. shockWaves: Reducir elasticity (decaySpeed) de 0.7 a 0.3
   - Las ondas de choque desaparecían muy rápido
   - Ahora duran más tiempo y son más visibles

4. Agregar interpolación suave con lerp_angle:
   - interferenceWaves: Usar lerp_angle en lugar de asignación directa
   - animatedFractals: Usar lerp_angle para transiciones suaves
   - crystallization: Usar lerp_angle para movimiento fluido
   - shockWaves: Usar lerp_angle para ondas más suaves

Todas las animaciones ahora se reproducen correctamente con movimiento fluido y visible.